### PR TITLE
Timer callback中の終了条件変更

### DIFF
--- a/dynamixel_workbench_controllers/src/dynamixel_workbench_controllers.cpp
+++ b/dynamixel_workbench_controllers/src/dynamixel_workbench_controllers.cpp
@@ -674,6 +674,7 @@ void DynamixelController::writeCallback(const ros::TimerEvent&)
       ROS_ERROR("%s", log);
     }
 
+    /*
     position_cnt++;
     if (position_cnt >= jnt_tra_msg_->points[point_cnt].positions.size())
     {
@@ -687,6 +688,15 @@ void DynamixelController::writeCallback(const ros::TimerEvent&)
 
         ROS_INFO("Complete Execution");
       }
+    */
+    point_cnt++;
+    if (point_cnt >= jnt_tra_msg_->points.size())
+    {
+      is_moving_ = false;
+      point_cnt = 0;
+      position_cnt = 0;
+
+      ROS_INFO("Complete Execution");
     }
   }
 


### PR DESCRIPTION
インターバルタイマーでモータ制御を行っているが，インターバル実行回数が「動作時間/タイマー間隔×制御個数」になっているため，結果「指定動作時間×制御個数」で動作完了するようになっているため指示どおりにうごかないので，それを修正．
